### PR TITLE
Add TabLine* highlights, improve Nvim-Tree visibility, follow background setting, and use main theme colours for Lualine

### DIFF
--- a/autoload/aquarium/colors.vim
+++ b/autoload/aquarium/colors.vim
@@ -1,0 +1,125 @@
+function aquarium#colors#definitions()
+  let l:style = get(g:, 'aquarium_style', &background)
+  let l:result = {}
+
+  if l:style ==# 'dark'
+    let l:result =
+          \{
+          \ 'gui00': "#20202A",
+          \ 'gui01': "#2C2E3E",
+          \ 'gui02': "#A7B7D6",
+          \ 'gui03': "#44495E",
+          \ 'gui04': "#C6D0E9",
+          \ 'gui05': "#63718B",
+          \ 'gui06': "#313449",
+          \ 'gui07': "#1A1A24",
+          \ 'gui08': "#EBB9B9",
+          \ 'gui09': "#E8CCA7",
+          \ 'gui0A': "#E6DFB8",
+          \ 'gui0B': "#B1DBA4",
+          \ 'gui0C': "#B8DEEB",
+          \ 'gui0D': "#CDDBF9",
+          \ 'gui0E': "#F6BBE7",
+          \ 'gui0F': "#EAC1C1",
+          \}
+    let l:result.linenr_bg = result.gui07
+    let l:result.linenr_fg = result.gui02
+    let l:result.cursor_bg = result.gui02
+  elseif l:style ==# 'light'
+    let l:result =
+          \{
+          \ 'gui00': "#E6E6F1",
+          \ 'gui01': "#D5D4E0",
+          \ 'gui02': "#7F8E9D",
+          \ 'gui03': "#CCCBD9",
+          \ 'gui04': "#7F8E9D",
+          \ 'gui05': "#708190",
+          \ 'gui06': "#9CA6B9",
+          \ 'gui07': "#D7D7E2",
+          \ 'gui08': "#C34864",
+          \ 'gui09': "#D66652",
+          \ 'gui0A': "#DE956F",
+          \ 'gui0B': "#7D9685",
+          \ 'gui0C': "#829FB0",
+          \ 'gui0D': "#6A8CBC",
+          \ 'gui0E': "#8787BF",
+          \ 'gui0F': "#E06B6B",
+          \}
+    let l:result.linenr_bg = result.gui01
+    let l:result.linenr_fg = "#414560"
+    let l:result.cursor_bg = "#AFB5C6"
+  elseif l:style ==# 'mish'
+    let l:result = 
+          \{
+          \ 'gui00': "#292B2F",
+          \ 'gui01': "#36393F",
+          \ 'gui02': "#97A1AF",
+          \ 'gui03': "#4D5664",
+          \ 'gui04': "#C8D0DA",
+          \ 'gui05': "#DCE4EE",
+          \ 'gui06': "#44484F",
+          \ 'gui07': "#1F2025",
+          \ 'gui08': "#EBB9B9",
+          \ 'gui09': "#EBD1B9",
+          \ 'gui0A': "#EBE3B9",
+          \ 'gui0B': "#C2EBB9",
+          \ 'gui0C': "#B9DEEB",
+          \ 'gui0D': "#B9CAEB",
+          \ 'gui0E': "#D9B9EB",
+          \ 'gui0F': "#EBB9D9",
+          \}
+    let l:result.linenr_bg = result.gui07
+    let l:result.linenr_fg = result.gui02
+    let l:result.cursor_bg = result.gui02
+  endif
+
+  " Trigger bold
+  if !exists("g:aqua_bold")
+    let g:aqua_bold = 1
+  endif
+
+  let l:result.bold = "bold,"
+  if g:aqua_bold == 0
+    let l:result.bold = ""
+  endif
+
+  " Focused line toggle
+  if !exists("g:aqua_line")
+    let g:aqua_line = 0
+  endif
+
+  let l:result.line = "NONE"
+  if g:aqua_line == 1
+    let l:result.line = l:result.gui07
+  endif
+
+  " Focused line Number toggle
+  if !exists("g:aqua_linenr")
+    let g:aqua_linenr = 0
+  endif
+
+  if g:aqua_linenr == 0
+    let l:result.linenr_bg = ""
+  endif
+
+  " Transparency thingy
+  if !exists("g:aqua_transparency")
+    let g:aqua_transparency = 0
+  endif
+
+  if g:aqua_transparency == 0
+    let l:result.normal = l:result.gui00
+    let l:result.buff = l:result.gui00
+    let l:result.fold_col = l:result.gui00
+    let l:result.sign_col = l:result.gui00
+    let l:result.folded = l:result.gui07
+  elseif g:aqua_transparency == 1
+    let l:result.normal = "NONE"
+    let l:result.buff = "NONE"
+    let l:result.folded = "NONE"
+    let l:result.fold_col = "NONE"
+    let l:result.sign_col = "NONE"
+  endif
+
+  return l:result
+endfunction

--- a/colors/aquarium.vim
+++ b/colors/aquarium.vim
@@ -62,6 +62,7 @@ if s:configuration.style ==# 'dark'
     let s:gui0D     = "#CDDBF9"
     let s:gui0E     = "#F6BBE7"
     let s:gui0F     = "#EAC1C1"
+    let s:gui10     = "#3D4059"
 
     " OTHER
     let s:linenr_bg = s:gui07
@@ -92,6 +93,7 @@ elseif s:configuration.style ==# 'light'
     let s:gui0D     = "#6A8CBC"
     let s:gui0E     = "#8787BF"
     let s:gui0F     = "#E06B6B"
+    let s:gui10     = "#CCCBD9"
 
     " OTHER
     let s:linenr_bg = s:gui01
@@ -240,6 +242,11 @@ call s:hi("iCursor", s:cursor_bg, s:gui06, "", "NONE", "", "")
 call s:hi("LineNr", s:gui03, s:gui00, "", "", "bold", "") " The Number Columns
 call s:hi("CursorLine", "", s:line, "NONE", "", "NONE", "") " Changes the color focused line where the cursor is
 call s:hi("CursorLineNr", s:linenr_fg, s:linenr_bg, "NONE", "", "NONE", "") " Changes the color focused column number where the cursor is
+
+" Tabs
+call s:hi("TabLineFill", s:gui0D, s:gui01, "NONE", "NONE", "NONE", "NONE")
+call s:hi("TabLineSel", s:gui10, s:gui0F, "NONE", "NONE", "bold", "NONE")
+call s:hi("TabLine", s:gui05, s:gui00, "NONE", "NONE", "NONE", "NONE") 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 "+-- Lang Specifics aka Fallbacks ---+

--- a/colors/aquarium.vim
+++ b/colors/aquarium.vim
@@ -16,155 +16,13 @@ endif
 
 " Naming
 let colors_name = "aquarium"
-let s:aquarium_vim_version="0.3.5"
-
-" Options
-let s:configuration = {}
-let s:configuration.style = get(g:, 'aquarium_style', &background)
-
-" Trigger bold
-if !exists("g:aqua_bold")
-  let g:aqua_bold = 1
-endif
-
-let s:bold = "bold,"
-if g:aqua_bold == 0
-  let s:bold = ""
-endif
+let s:aquarium_vim_version="0.3.6"
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+
 "+----- Color Thingy ------+
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-if s:configuration.style ==# 'dark'
-
-    " BASE BG
-    let s:gui00     = "#20202A"
-    let s:gui01     = "#2C2E3E"
-    let s:gui02     = "#A7B7D6"
-    let s:gui03     = "#44495E"
-
-    " BASE FG
-    let s:gui04     = "#C6D0E9"
-    let s:gui05     = "#63718B"
-
-    let s:gui06     = "#313449"
-    let s:gui07     = "#1A1A24"
-
-    " OTHER COLORS
-    let s:gui08     = "#EBB9B9"
-    let s:gui09     = "#E8CCA7"
-    let s:gui0A     = "#E6DFB8"
-    let s:gui0B     = "#B1DBA4"
-    let s:gui0C     = "#B8DEEB"
-    let s:gui0D     = "#CDDBF9"
-    let s:gui0E     = "#F6BBE7"
-    let s:gui0F     = "#EAC1C1"
-
-    " OTHER
-    let s:linenr_bg = s:gui07
-    let s:linenr_fg = s:gui02
-    let s:cursor_bg = s:gui02
-
-elseif s:configuration.style ==# 'light'
-
-    " BASE BG
-    " Old BG -> #E6E6F1 #E1E3F2
-    let s:gui00     = "#E6E6F1"
-    let s:gui01     = "#D5D4E0"
-    let s:gui02     = "#7F8E9D"
-    let s:gui03     = "#CCCBD9"
-    let s:gui06     = "#9CA6B9"
-    let s:gui07     = "#D7D7E2"
-
-    " BASE FG
-    let s:gui04     = "#7F8E9D"
-    let s:gui05     = "#708190"
-
-    " OTHER COLORS
-    let s:gui08     = "#C34864"
-    let s:gui09     = "#D66652"
-    let s:gui0A     = "#DE956F"
-    let s:gui0B     = "#7D9685"
-    let s:gui0C     = "#829FB0"
-    let s:gui0D     = "#6A8CBC"
-    let s:gui0E     = "#8787BF"
-    let s:gui0F     = "#E06B6B"
-
-    " OTHER
-    let s:linenr_bg = s:gui01
-    let s:linenr_fg = "#414560"
-    let s:cursor_bg = "#AFB5C6"
-elseif s:configuration.style ==# 'mish'
-
-    " BASE BG
-    let s:gui00     = "#292B2F"
-    let s:gui01     = "#36393F"
-
-    let s:gui02     = "#97A1AF"
-    let s:gui03     = "#4D5664"
-
-    " BASE FG
-    let s:gui04     = "#C8D0DA"
-    let s:gui05     = "#DCE4EE"
-
-    let s:gui06     = "#44484F"
-    let s:gui07     = "#1F2025"
-
-    " OTHER COLORS
-    let s:gui08     = "#EBB9B9"
-    let s:gui09     = "#EBD1B9"
-    let s:gui0A     = "#EBE3B9"
-    let s:gui0B     = "#C2EBB9"
-    let s:gui0C     = "#B9DEEB"
-    let s:gui0D     = "#B9CAEB"
-    let s:gui0E     = "#D9B9EB"
-    let s:gui0F     = "#EBB9D9"
-
-    " OTHER
-    let s:linenr_bg = s:gui07
-    let s:linenr_fg = s:gui02
-    let s:cursor_bg = s:gui02
-endif
-
-" Focused line toggle
-if !exists("g:aqua_line")
-    let g:aqua_line = 0
-endif
-
-let s:line = "NONE"
-if g:aqua_line == 1
-    let s:line = s:gui07
-endif
-
-" Focused line Number toggle
-if !exists("g:aqua_linenr")
-    let g:aqua_linenr = 0
-endif
-
-if g:aqua_linenr == 0
-    let s:linenr_bg = ""
-endif
-
-" Transparency thingy
-if !exists("g:aqua_transparency")
-    let g:aqua_transparency = 0
-endif
-
-if g:aqua_transparency == 0
-    let s:normal = s:gui00
-    let s:buff = s:gui00
-    let s:fold_col = s:gui00
-    let s:sign_col = s:gui00
-    let s:folded = s:gui07
-elseif g:aqua_transparency == 1
-    let s:normal = "NONE"
-    let s:buff = "NONE"
-    let s:folded = "NONE"
-    let s:fold_col = "NONE"
-    let s:sign_col = "NONE"
-endif
-
+let s:colors = aquarium#colors#definitions()
 
 " Function Loader thingy
 function! s:hi(group, guifg, guibg, ctermfg, ctermbg, attr, guisp)
@@ -192,7 +50,7 @@ endfunction
 "+-+-+-+-+-+-+-+-+-+-+
 "+--- Attributes ----+
 "+-+-+-+-+-+-+-+-+-+-+
-call s:hi("Bold", "", "", "", "", s:bold, "")
+call s:hi("Bold", "", "", "", "", s:colors.bold, "")
 call s:hi("Italic", "", "", "", "", "italic", "")
 call s:hi("Underline", "", "", "", "", "underline", "")
 
@@ -200,85 +58,85 @@ call s:hi("Underline", "", "", "", "", "underline", "")
 "+-+-+-+-+-+-+-+-+-+-+
 "+----- Editor ------+
 "+-+-+-+-+-+-+-+-+-+-+
-call s:hi("Normal", s:gui05, s:normal, "NONE", "NONE", "", "")
-call s:hi("Error", s:gui08, s:gui01, "", "", "italic", "")
-call s:hi("Search", s:gui0A, s:gui02, "", "", "", "") " Last search pattern highlighting (see 'hlsearch'). Also used for similar items that need to stand out.
-call s:hi("MatchParen", s:gui0C, s:gui02, "", "", "", "")
-call s:hi("NonText", s:gui05, s:gui02, "", "", "", "")
-call s:hi("Special", s:gui0A, "", "", "", "italic", "")
-call s:hi("SpecialKey", s:gui02, "", "", "", "", "")
-call s:hi("Conceal", "", s:gui03, "", "NONE", "", "") " placeholder characters substituted for concealed text (see 'conceallevel')
-call s:hi("IncSearch", s:gui0E, s:gui01, "NONE", "NONE", "", "")
+call s:hi("Normal", s:colors.gui05, s:colors.normal, "NONE", "NONE", "", "")
+call s:hi("Error", s:colors.gui08, s:colors.gui01, "", "", "italic", "")
+call s:hi("Search", s:colors.gui0A, s:colors.gui02, "", "", "", "") " Last search pattern highlighting (see 'hlsearch'). Also used for similar items that need to stand out.
+call s:hi("MatchParen", s:colors.gui0C, s:colors.gui02, "", "", "", "")
+call s:hi("NonText", s:colors.gui05, s:colors.gui02, "", "", "", "")
+call s:hi("Special", s:colors.gui0A, "", "", "", "italic", "")
+call s:hi("SpecialKey", s:colors.gui02, "", "", "", "", "")
+call s:hi("Conceal", "", s:colors.gui03, "", "NONE", "", "") " placeholder characters substituted for concealed text (see 'conceallevel')
+call s:hi("IncSearch", s:colors.gui0E, s:colors.gui01, "NONE", "NONE", "", "")
 
 " Comments and Such
-call s:hi("Comment", s:gui03, "", "", "", "italic", "")
-call s:hi("SpecialComment", s:gui02, "", "", "", "italic", "")
+call s:hi("Comment", s:colors.gui03, "", "", "", "italic", "")
+call s:hi("SpecialComment", s:colors.gui02, "", "", "", "italic", "")
 
 " Pmenu
-call s:hi("Pmenu", s:gui05, s:gui01, "", "", "", "")
-call s:hi("PmenuSbar",  s:gui05, s:gui01, "", "", "", "")
-call s:hi("PmenuSel", s:gui0C, s:gui01, "", "", "", "")
-call s:hi("PmenuThumb", s:gui0C, s:gui01, "", "", "", "")
+call s:hi("Pmenu", s:colors.gui05, s:colors.gui01, "", "", "", "")
+call s:hi("PmenuSbar",  s:colors.gui05, s:colors.gui01, "", "", "", "")
+call s:hi("PmenuSel", s:colors.gui0C, s:colors.gui01, "", "", "", "")
+call s:hi("PmenuThumb", s:colors.gui0C, s:colors.gui01, "", "", "", "")
 
 " Columns
-call s:hi("SignColumn", s:gui0D, s:sign_col, "NONE", "", "", "")
-call s:hi("ColorColumn", "", s:gui01, "NONE", "", "", "")
-call s:hi("CursorColumn", s:gui0C, s:gui00, "NONE", "", "", "")
+call s:hi("SignColumn", s:colors.gui0D, s:colors.sign_col, "NONE", "", "", "")
+call s:hi("ColorColumn", "", s:colors.gui01, "NONE", "", "", "")
+call s:hi("CursorColumn", s:colors.gui0C, s:colors.gui00, "NONE", "", "", "")
 
 " Folding
-call s:hi("FoldColumn", s:gui06, s:gui01, "NONE", "", "", "")
-call s:hi("Folded", s:gui02, s:folded, "NONE", "", "", "")
+call s:hi("FoldColumn", s:colors.gui06, s:colors.gui01, "NONE", "", "", "")
+call s:hi("Folded", s:colors.gui02, s:colors.folded, "NONE", "", "", "")
 
 " Cursor
-call s:hi("Cursor", s:cursor_bg, s:gui06, "NONE", "NONE", "", "") " Regular Cursor thing
-call s:hi("CursorIM", s:gui02, s:gui06, "", "NONE", "", "") " like Cursor, but used when in IME mode
-call s:hi("iCursor", s:cursor_bg, s:gui06, "", "NONE", "", "")
+call s:hi("Cursor", s:colors.cursor_bg, s:colors.gui06, "NONE", "NONE", "", "") " Regular Cursor thing
+call s:hi("CursorIM", s:colors.gui02, s:colors.gui06, "", "NONE", "", "") " like Cursor, but used when in IME mode
+call s:hi("iCursor", s:colors.cursor_bg, s:colors.gui06, "", "NONE", "", "")
 
 " Line Stuff
-call s:hi("LineNr", s:gui03, s:gui00, "", "", "bold", "") " The Number Columns
-call s:hi("CursorLine", "", s:line, "NONE", "", "NONE", "") " Changes the color focused line where the cursor is
-call s:hi("CursorLineNr", s:linenr_fg, s:linenr_bg, "NONE", "", "NONE", "") " Changes the color focused column number where the cursor is
+call s:hi("LineNr", s:colors.gui03, s:colors.gui00, "", "", s:colors.bold, "") " The Number Columns
+call s:hi("CursorLine", "", s:colors.line, "NONE", "", "NONE", "") " Changes the color focused line where the cursor is
+call s:hi("CursorLineNr", s:colors.linenr_fg, s:colors.linenr_bg, "NONE", "", "NONE", "") " Changes the color focused column number where the cursor is
 
 " Tabs
-call s:hi("TabLineFill", s:gui0D, s:gui01, "NONE", "NONE", "NONE", "NONE")
-call s:hi("TabLineSel", s:gui03, s:gui0F, "NONE", "NONE", "bold", "NONE")
-call s:hi("TabLine", s:gui05, s:gui00, "NONE", "NONE", "NONE", "NONE") 
+call s:hi("TabLineFill", s:colors.gui0D, s:colors.gui01, "NONE", "NONE", "NONE", "NONE")
+call s:hi("TabLineSel", s:colors.gui03, s:colors.gui0F, "NONE", "NONE", s:colors.bold, "NONE")
+call s:hi("TabLine", s:colors.gui05, s:colors.gui00, "NONE", "NONE", "NONE", "NONE") 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 "+-- Lang Specifics aka Fallbacks ---+
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("PreProc", s:gui0E, "", "", "", "", "")
-call s:hi("Todo", s:gui0E, s:gui01, "", "", s:bold, "") " anything that needs extra attention; mostly the keywords TODO FIXME and XXX
-call s:hi("Boolean", s:gui09, "", "", "", "", "") " a boolean constant: TRUE, false
-call s:hi("Type", s:gui0A, "", "", "", "italic", "" ) " int, long, char, etc.
-call s:hi("Function", s:gui0C, "", "", "", "italic", "") " a floating point constant: 2.3e10
-call s:hi("Include", s:gui0D, "", "", "", "", "" ) " preprocessor #include
-call s:hi("Statement", s:gui0D, "", "", "", "", "" ) " any statement
-call s:hi("Conditional", s:gui0C, "", "", "", "", "") " if, then, else, endif, switch, etc.
-call s:hi("Repeat", s:gui0A, "", "", "", "", "") " for, do, while, etc.
-call s:hi("Label", s:gui0A,"", "", "", "", "") " case, default, etc.
-call s:hi("String", s:gui0B, "", "", "", "", "") " a string constant: 'this is a string'
-call s:hi("Character", s:gui0B, "", "", "", "", "") " a character constant: 'c', '\n'
-call s:hi("StorageClass", s:gui0A, "", "", "", "", "") " static, register, volatile, etc.
-call s:hi("Operator", s:gui08, "", "", "", s:bold, "") " sizeof, '+', '*', etc.
-call s:hi("Number", s:gui09, "", "", "", "", "") " a number constant: 234, 0xff
-call s:hi("Float", s:gui08, "", "", "", "", "") " a floating point constant: 2.3e10
-call s:hi("Structure", s:gui0A, "", "", "", "", "" ) " struct, union, enum, etc.
-call s:hi("Typedef", s:gui0A, "", "", "", "", "") " A typedef
-call s:hi("Special", s:gui0D, "", "", "", "", "") " any special symbol
-call s:hi("SpecialChar", s:gui01, "", "", "", "", "") " special character in a constant
-call s:hi("Decorator", s:gui0E, "", "", "", "", "")
-call s:hi("Tag", s:gui0A, "", "", "", "", "") " you can use CTRL-] on this
-call s:hi("Delimiter", s:gui0D, "", "", "", s:bold, "") " character that needs attention, parenthesis for example
-call s:hi("Macro", s:gui0E, "", "", "", "", "") " same as Define
-call s:hi("Exception", s:gui0E, "", "", "", "", "") " try, catch, throw
+call s:hi("PreProc", s:colors.gui0E, "", "", "", "", "")
+call s:hi("Todo", s:colors.gui0E, s:colors.gui01, "", "", s:colors.bold, "") " anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+call s:hi("Boolean", s:colors.gui09, "", "", "", "", "") " a boolean constant: TRUE, false
+call s:hi("Type", s:colors.gui0A, "", "", "", "italic", "" ) " int, long, char, etc.
+call s:hi("Function", s:colors.gui0C, "", "", "", "italic", "") " a floating point constant: 2.3e10
+call s:hi("Include", s:colors.gui0D, "", "", "", "", "" ) " preprocessor #include
+call s:hi("Statement", s:colors.gui0D, "", "", "", "", "" ) " any statement
+call s:hi("Conditional", s:colors.gui0C, "", "", "", "", "") " if, then, else, endif, switch, etc.
+call s:hi("Repeat", s:colors.gui0A, "", "", "", "", "") " for, do, while, etc.
+call s:hi("Label", s:colors.gui0A,"", "", "", "", "") " case, default, etc.
+call s:hi("String", s:colors.gui0B, "", "", "", "", "") " a string constant: 'this is a string'
+call s:hi("Character", s:colors.gui0B, "", "", "", "", "") " a character constant: 'c', '\n'
+call s:hi("StorageClass", s:colors.gui0A, "", "", "", "", "") " static, register, volatile, etc.
+call s:hi("Operator", s:colors.gui08, "", "", "", s:colors.bold, "") " sizeof, '+', '*', etc.
+call s:hi("Number", s:colors.gui09, "", "", "", "", "") " a number constant: 234, 0xff
+call s:hi("Float", s:colors.gui08, "", "", "", "", "") " a floating point constant: 2.3e10
+call s:hi("Structure", s:colors.gui0A, "", "", "", "", "" ) " struct, union, enum, etc.
+call s:hi("Typedef", s:colors.gui0A, "", "", "", "", "") " A typedef
+call s:hi("Special", s:colors.gui0D, "", "", "", "", "") " any special symbol
+call s:hi("SpecialChar", s:colors.gui01, "", "", "", "", "") " special character in a constant
+call s:hi("Decorator", s:colors.gui0E, "", "", "", "", "")
+call s:hi("Tag", s:colors.gui0A, "", "", "", "", "") " you can use CTRL-] on this
+call s:hi("Delimiter", s:colors.gui0D, "", "", "", s:colors.bold, "") " character that needs attention, parenthesis for example
+call s:hi("Macro", s:colors.gui0E, "", "", "", "", "") " same as Define
+call s:hi("Exception", s:colors.gui0E, "", "", "", "", "") " try, catch, throw
 call s:hi("Delimiter", "", "", "", "", "", "") " character that needs attention
-call s:hi("Keyword", s:gui08, "", "", "", "italic", "") " any other keyword
+call s:hi("Keyword", s:colors.gui08, "", "", "", "italic", "") " any other keyword
 call s:hi("Debug", "", "", "", "", "", "") " debugging statements
 call s:hi("Underlined", "", "", "", "", "underline", "") " text that stands out, HTML links
-call s:hi("Identifier", s:gui08, "", "", "", "", "") " any variable name
-call s:hi("Constant", s:gui0E, "", "", "", "italic", "")
-call s:hi("WildMenu", s:gui0D, s:gui01, "", "", "", "")
+call s:hi("Identifier", s:colors.gui08, "", "", "", "", "") " any variable name
+call s:hi("Constant", s:colors.gui0E, "", "", "", "italic", "")
+call s:hi("WildMenu", s:colors.gui0D, s:colors.gui01, "", "", "", "")
 hi! link PreCondit PreProc
 hi! link Annotation Decorator
 hi! link Variable Identifier
@@ -287,26 +145,26 @@ hi! link Variable Identifier
 "+-+-+-+-+-+-+-+-+-+-+-+-+
 "+--- Window Highlight --+
 "+-+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("VertSplit", s:gui01, s:gui00, "", "NONE", s:bold, "")
-call s:hi("StatusLine", s:gui00, s:gui03, "", "", "", "") " status line of current window
-call s:hi("StatusLineNC", s:gui01, s:gui00, "", "", "underline", "") "status lines of not-current windows Note: if this is equal to 'StatusLine' Vim will use '^^^' in the status line of the current window.
-call s:hi("StatusLineTerm", s:gui05, s:gui00, "", "", "", "" ) " status line of current :terminal window
-call s:hi("StatusLineTermNC", s:gui06, s:gui00, "", "", "underline", "") " status line of non-current :terminal window
+call s:hi("VertSplit", s:colors.gui01, s:colors.gui00, "", "NONE", s:colors.bold, "")
+call s:hi("StatusLine", s:colors.gui00, s:colors.gui03, "", "", "", "") " status line of current window
+call s:hi("StatusLineNC", s:colors.gui01, s:colors.gui00, "", "", "underline", "") "status lines of not-current windows Note: if this is equal to 'StatusLine' Vim will use '^^^' in the status line of the current window.
+call s:hi("StatusLineTerm", s:colors.gui05, s:colors.gui00, "", "", "", "" ) " status line of current :terminal window
+call s:hi("StatusLineTermNC", s:colors.gui06, s:colors.gui00, "", "", "underline", "") " status line of non-current :terminal window
 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+
 "+--- Ascii Hightlight --+
 "+-+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("asciidocAttributeEntry", s:gui0D, "", "", "", "", "")
-call s:hi("asciidocAttributeList", s:gui0D, "", "", "", "", "")
-call s:hi("asciidocAttributeRef", s:gui0D, "", "", "", "", "")
-call s:hi("asciidocHLabel", s:gui0E, "", "", "", "", "" )
-call s:hi("asciidocListingBlock", s:gui0A, "", "", "", "", "")
-call s:hi("asciidocMacroAttributes", s:gui0C, "", "", "", "", "")
-call s:hi("asciidocOneLineTitle", s:gui0C, "", "", "", "", "")
-call s:hi("asciidocPassthroughBlock", s:gui0E, "", "", "", "", "")
-call s:hi("asciidocQuotedMonospaced", s:gui0C, "", "", "", "", "")
-call s:hi("asciidocTriplePlusPassthrough", s:gui0A, "", "", "", "", "")
+call s:hi("asciidocAttributeEntry", s:colors.gui0D, "", "", "", "", "")
+call s:hi("asciidocAttributeList", s:colors.gui0D, "", "", "", "", "")
+call s:hi("asciidocAttributeRef", s:colors.gui0D, "", "", "", "", "")
+call s:hi("asciidocHLabel", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("asciidocListingBlock", s:colors.gui0A, "", "", "", "", "")
+call s:hi("asciidocMacroAttributes", s:colors.gui0C, "", "", "", "", "")
+call s:hi("asciidocOneLineTitle", s:colors.gui0C, "", "", "", "", "")
+call s:hi("asciidocPassthroughBlock", s:colors.gui0E, "", "", "", "", "")
+call s:hi("asciidocQuotedMonospaced", s:colors.gui0C, "", "", "", "", "")
+call s:hi("asciidocTriplePlusPassthrough", s:colors.gui0A, "", "", "", "", "")
 hi! link asciidocAdmonition Keyword
 hi! link asciidocAttributeRef markdownH1
 hi! link asciidocBackslash Keyword
@@ -322,32 +180,32 @@ hi! link asciidocURL markdownLinkText
 "+-+-+-+-+-+-+-+-+-+-+-+
 "+--- Prompt/Status ---+
 "+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("EndOfBuffer", s:buff, "", "", "", "", "")
-call s:hi("ErrorMsg", s:gui08, s:gui00, "", "", "italic", "")
-call s:hi("ModeMsg", s:gui05, "", "", "", "", "")
-call s:hi("MoreMsg", s:gui0C, s:gui02, "", "", "", "")
-call s:hi("Question", s:gui05, "", "NONE", "", "", "")
+call s:hi("EndOfBuffer", s:colors.buff, "", "", "", "", "")
+call s:hi("ErrorMsg", s:colors.gui08, s:colors.gui00, "", "", "italic", "")
+call s:hi("ModeMsg", s:colors.gui05, "", "", "", "", "")
+call s:hi("MoreMsg", s:colors.gui0C, s:colors.gui02, "", "", "", "")
+call s:hi("Question", s:colors.gui05, "", "NONE", "", "", "")
 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+
 "+--- Cmake Hightlight --+
 "+-+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("cmakeGeneratorExpression", s:gui0D, "", "", "", "italic", "")
+call s:hi("cmakeGeneratorExpression", s:colors.gui0D, "", "", "", "italic", "")
 
 
 "+-+-+-+-+-+-+-+-+-+-+-+
 "+- Neovim Support -+
 "+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("healthError", s:gui08, s:gui01, "", "", "", "")
-call s:hi("healthSuccess", s:gui0B, s:gui01, "", "", "", "")
-call s:hi("healthWarning", s:gui0A, s:gui01, "", "", "", "")
+call s:hi("healthError", s:colors.gui08, s:colors.gui01, "", "", "", "")
+call s:hi("healthSuccess", s:colors.gui0B, s:colors.gui01, "", "", "", "")
+call s:hi("healthWarning", s:colors.gui0A, s:colors.gui01, "", "", "", "")
 
 
 "+-+-+-+-+-+-+-+-+-+-+
 "+-- Awk Highlight --+
 "+-+-+-+-+-+-+-+-+-+-+
-call s:hi("awkCharClass", s:gui0A, "", "", "", "italic", "")
-call s:hi("awkPatterns", s:gui0C,  "", "", "", "italic", "")
+call s:hi("awkCharClass", s:colors.gui0A, "", "", "", "italic", "")
+call s:hi("awkPatterns", s:colors.gui0C,  "", "", "", "italic", "")
 hi! link awkArrayElement Identifier
 hi! link awkBoolLogic Keyword
 hi! link awkBrktRegExp SpecialChar
@@ -368,38 +226,38 @@ hi! link awkVariables Identifier
 "+-- Spell Check Highlight --+
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 " Word that is not recognized by the spellchecker. This will be combined with the highlighting used otherwise.
-call s:hi("SpellBad", s:gui08, s:gui01, "", "", "undercurl", "")
+call s:hi("SpellBad", s:colors.gui08, s:colors.gui01, "", "", "undercurl", "")
 " Word that should start with a capital. This will be combined with the highlighting used otherwise.
-call s:hi("SpellCap", s:gui0A, s:gui01, "", "", "undercurl", "")
+call s:hi("SpellCap", s:colors.gui0A, s:colors.gui01, "", "", "undercurl", "")
 " Word that is recognized by the spellchecker as one that is used in another region. This will be combined with the highlighting used otherwise.
-call s:hi("SpellLocal", s:gui09, s:gui01, "", "", "undercurl", "")
+call s:hi("SpellLocal", s:colors.gui09, s:colors.gui01, "", "", "undercurl", "")
 " Word that is recognized by the spellchecker as one that is hardly ever used. spell This will be combined with the highlighting used otherwise.
-call s:hi("SpellRare", s:gui0D, s:gui01, "", "", "undercurl", "")
+call s:hi("SpellRare", s:colors.gui0D, s:colors.gui01, "", "", "undercurl", "")
 
 
 "+-+-+-+-+-+-+-+-+-+-+
 "+ Visual Something  +
 "+-+-+-+-+-+-+-+-+-+-+
-call s:hi("Visual", "", s:gui01, "", "", "", "")
-call s:hi("VisualNOS", "", s:gui01, "", "", "", "")
+call s:hi("Visual", "", s:colors.gui01, "", "", "", "")
+call s:hi("VisualNOS", "", s:colors.gui01, "", "", "", "")
 
 "+-+-+-+-+-+-+-+-+-+-+
 "+ Git Highlighting  +
 "+-+-+-+-+-+-+-+-+-+-+
-call s:hi("gitcommitComment", s:gui02, "", "", "", "", "")
-call s:hi("gitcommitUnmerged", s:gui0B, "", "", "", "", "")
-call s:hi("gitcommitOnBranch", s:gui0C, "", "", "", "", "")
-call s:hi("gitcommitBranch", s:gui0E, "", "", "", "", "")
-call s:hi("gitcommitDiscardedType", s:gui08, "", "", "", "", "")
-call s:hi("gitcommitSelectedType", s:gui0B, "", "", "", "", "")
-call s:hi("gitcommitHeader", s:gui0B, "", "", "", "", "")
-call s:hi("gitcommitUntrackedFile", s:gui0C, "", "", "", "", "")
-call s:hi("gitcommitDiscardedFile", s:gui08, "", "", "", "", "")
-call s:hi("gitcommitSelectedFile", s:gui0B, "", "", "", "", "")
-call s:hi("gitcommitUnmergedFile", s:gui0A, "", "", "", "", "")
-call s:hi("gitcommitFile", s:gui0E, "", "", "", "", "")
-call s:hi("gitcommitSummary", s:gui05, "", "", "", "", "")
-call s:hi("gitcommitOverflow", s:gui08, "", "", "", "", "")
+call s:hi("gitcommitComment", s:colors.gui02, "", "", "", "", "")
+call s:hi("gitcommitUnmerged", s:colors.gui0B, "", "", "", "", "")
+call s:hi("gitcommitOnBranch", s:colors.gui0C, "", "", "", "", "")
+call s:hi("gitcommitBranch", s:colors.gui0E, "", "", "", "", "")
+call s:hi("gitcommitDiscardedType", s:colors.gui08, "", "", "", "", "")
+call s:hi("gitcommitSelectedType", s:colors.gui0B, "", "", "", "", "")
+call s:hi("gitcommitHeader", s:colors.gui0B, "", "", "", "", "")
+call s:hi("gitcommitUntrackedFile", s:colors.gui0C, "", "", "", "", "")
+call s:hi("gitcommitDiscardedFile", s:colors.gui08, "", "", "", "", "")
+call s:hi("gitcommitSelectedFile", s:colors.gui0B, "", "", "", "", "")
+call s:hi("gitcommitUnmergedFile", s:colors.gui0A, "", "", "", "", "")
+call s:hi("gitcommitFile", s:colors.gui0E, "", "", "", "", "")
+call s:hi("gitcommitSummary", s:colors.gui05, "", "", "", "", "")
+call s:hi("gitcommitOverflow", s:colors.gui08, "", "", "", "", "")
 hi link gitcommitNoBranch gitcommitBranch
 hi link gitcommitUntracked gitcommitComment
 hi link gitcommitDiscarded gitcommitComment
@@ -416,13 +274,13 @@ if &diff
   " Don't change the background color in diff mode
   call s:hi("CursorLine", "", "", "", "", "underline", "") " the screen line that the cursor is in when 'cursorline' is set
 else
-  call s:hi("CursorLine", "", s:line, "", "", "", "" ) " the screen line that the cursor is in when 'cursorline' is set
+  call s:hi("CursorLine", "", s:colors.line, "", "", "", "" ) " the screen line that the cursor is in when 'cursorline' is set
 endif
-call s:hi("Directory", s:gui0D, "", "", "", "", "") " directory names (and other special names in listings)
-call s:hi("DiffAdd", s:gui0B, s:gui00, "", "", "", "") " diff mode: Added line
-call s:hi("DiffChange", s:gui0C, s:gui00, "", "", "", "") " diff mode: Changed line
-call s:hi("DiffDelete", s:gui08, s:gui00, "", "", "", "") " diff mode: Deleted line
-call s:hi("DiffText", s:gui0A, s:gui00, "", "", "", "") " diff mode: Changed text within a changed line
+call s:hi("Directory", s:colors.gui0D, "", "", "", "", "") " directory names (and other special names in listings)
+call s:hi("DiffAdd", s:colors.gui0B, s:colors.gui00, "", "", "", "") " diff mode: Added line
+call s:hi("DiffChange", s:colors.gui0C, s:colors.gui00, "", "", "", "") " diff mode: Changed line
+call s:hi("DiffDelete", s:colors.gui08, s:colors.gui00, "", "", "", "") " diff mode: Deleted line
+call s:hi("DiffText", s:colors.gui0A, s:colors.gui00, "", "", "", "") " diff mode: Changed text within a changed line
 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -432,17 +290,17 @@ call s:hi("DiffText", s:gui0A, s:gui00, "", "", "", "") " diff mode: Changed tex
 "+------------------+
 "+ C Lang Highlight +
 "+------------------+
-call s:hi("cIncluded", s:gui0A, "", "", "", "", "")
+call s:hi("cIncluded", s:colors.gui0A, "", "", "", "", "")
 hi! link cOperator Operator
 hi! link cPreCondit PreCondit
 
 "+--------------------+
 "+ CS Lang Hightlight +
 "+--------------------+
-call s:hi("cssAttributeSelector", s:gui0A, "", "", "", "", "")
-call s:hi("cssDefinition", s:gui0A, "", "", "", "NONE", "")
-call s:hi("cssIdentifier", s:gui0A, "", "", "", "underline", "")
-call s:hi("cssStringQ", s:gui0B, "", "", "", "", "")
+call s:hi("cssAttributeSelector", s:colors.gui0A, "", "", "", "", "")
+call s:hi("cssDefinition", s:colors.gui0A, "", "", "", "NONE", "")
+call s:hi("cssIdentifier", s:colors.gui0A, "", "", "", "underline", "")
+call s:hi("cssStringQ", s:colors.gui0B, "", "", "", "", "")
 hi! link cssAttr Keyword
 hi! link cssBraces Delimiter
 hi! link cssClassName cssDefinition
@@ -458,51 +316,51 @@ hi! link csXmlTag SpecialComment
 "+-+-+-+-+-+-+-+-+-+-+-+-+
 "+-- XML Lang Highlight -+
 "+-+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("xmlAttrib", s:gui0A, "", "", "", "", "" )
-call s:hi("xmlEndTag", s:gui08, "", "", "", "", "" )
-call s:hi("xmlTag", s:gui08, "", "", "", "", "" )
-call s:hi("xmlTagName", s:gui08, "", "", "", "", "" )
+call s:hi("xmlAttrib", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("xmlEndTag", s:colors.gui08, "", "", "", "", "" )
+call s:hi("xmlTag", s:colors.gui08, "", "", "", "", "" )
+call s:hi("xmlTagName", s:colors.gui08, "", "", "", "", "" )
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+
 "+-- TeX Lang Highlight -+
 "+-+-+-+-+-+-+-+-+-+-+-+-+
-call s:hi("texStatement", s:gui0E, "", "", "", "", "" )
-call s:hi("texSubscripts", s:gui0A, "", "", "", "", "" )
-call s:hi("texSuperscripts", s:gui0A, "", "", "", "", "" )
-call s:hi("texTodo", s:gui03, "", "", "", "", "" )
-call s:hi("texBeginEnd", s:gui0E, "", "", "", "", "" )
-call s:hi("texBeginEndName", s:gui0D, "", "", "", "", "" )
-call s:hi("texMathMatcher", s:gui0D, "", "", "", "", "" )
-call s:hi("texMathDelim", s:gui0D, "", "", "", "", "" )
-call s:hi("texDelimiter", s:gui0A, "", "", "", "", "" )
-call s:hi("texSpecialChar", s:gui0A, "", "", "", "", "" )
-call s:hi("texCite", s:gui0D, "", "", "", "", "" )
-call s:hi("texRefZone", s:gui0D, "", "", "", "", "" )
+call s:hi("texStatement", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("texSubscripts", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("texSuperscripts", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("texTodo", s:colors.gui03, "", "", "", "", "" )
+call s:hi("texBeginEnd", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("texBeginEndName", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("texMathMatcher", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("texMathDelim", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("texDelimiter", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("texSpecialChar", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("texCite", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("texRefZone", s:colors.gui0D, "", "", "", "", "" )
 
 "+-------------------+
 "+ Go Lang Highlight +
 "+-------------------+
-call s:hi("goDeclaration", s:gui0E, "", "", "", "", "")
-call s:hi("goBuiltins", s:gui0C, "", "", "", "", "")
-call s:hi("goFunctionCall", s:gui0D, "", "", "", "", "")
-call s:hi("goVarDefs", s:gui08, "", "", "", "", "")
-call s:hi("goVarAssign", s:gui08, "", "", "", "", "")
-call s:hi("goVar", s:gui0E, "", "", "", "", "")
-call s:hi("goConst", s:gui0E, "", "", "", "", "")
-call s:hi("goType", s:gui0A, "", "", "", "", "")
-call s:hi("goTypeName", s:gui0A, "", "", "", "", "" )
-call s:hi("goDeclType", s:gui0C, "", "", "", "", "" )
-call s:hi("goTypeDecl", s:gui0E, "", "", "", "", "" )
+call s:hi("goDeclaration", s:colors.gui0E, "", "", "", "", "")
+call s:hi("goBuiltins", s:colors.gui0C, "", "", "", "", "")
+call s:hi("goFunctionCall", s:colors.gui0D, "", "", "", "", "")
+call s:hi("goVarDefs", s:colors.gui08, "", "", "", "", "")
+call s:hi("goVarAssign", s:colors.gui08, "", "", "", "", "")
+call s:hi("goVar", s:colors.gui0E, "", "", "", "", "")
+call s:hi("goConst", s:colors.gui0E, "", "", "", "", "")
+call s:hi("goType", s:colors.gui0A, "", "", "", "", "")
+call s:hi("goTypeName", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("goDeclType", s:colors.gui0C, "", "", "", "", "" )
+call s:hi("goTypeDecl", s:colors.gui0E, "", "", "", "", "" )
 
 "+---------------------+
 "+ Rust Lang Highlight +
 "+---------------------+
-call s:hi("rustAttribute", s:gui0D, "", "", "", "", "")
-call s:hi("rustEnum", s:gui09, "", "", "", s:bold, "")
-call s:hi("rustMacro", s:gui0C, "", "", "", s:bold, "")
-call s:hi("rustModPath", s:gui0A, "", "", "", "", "")
-call s:hi("rustPanic", s:gui08, "", "", "", s:bold, "")
-call s:hi("rustTrait", s:gui0A, "", "", "", "italic", "")
+call s:hi("rustAttribute", s:colors.gui0D, "", "", "", "", "")
+call s:hi("rustEnum", s:colors.gui09, "", "", "", s:colors.bold, "")
+call s:hi("rustMacro", s:colors.gui0C, "", "", "", s:colors.bold, "")
+call s:hi("rustModPath", s:colors.gui0A, "", "", "", "", "")
+call s:hi("rustPanic", s:colors.gui08, "", "", "", s:colors.bold, "")
+call s:hi("rustTrait", s:colors.gui0A, "", "", "", "italic", "")
 hi! link rustCommentLineDoc Comment
 hi! link rustDerive rustAttribute
 hi! link rustEnumVariant rustEnum
@@ -512,140 +370,140 @@ hi! link rustQuestionMark Keyword
 "+--------------------+
 "+ CSS Lang Highlight +
 "+--------------------+
-call s:hi("cssAttrComma", s:gui0E, "", "", "", "", "" )
-call s:hi("cssAttributeSelector", s:gui0B, "", "", "", "", "" )
-call s:hi("cssBraces", s:gui0E, "", "", "", "", "" )
-call s:hi("cssClassName", s:gui0A, "", "", "", "", "" )
-call s:hi("cssClassNameDot", s:gui0A, "", "", "", "", "" )
-call s:hi("cssDefinition", s:gui0E, "", "", "", "", "" )
-call s:hi("cssFontAttr", s:gui0A, "", "", "", "", "" )
-call s:hi("cssFontDescriptor", s:gui0E, "", "", "", "", "" )
-call s:hi("cssFunctionName", s:gui0D, "", "", "", "", "" )
-call s:hi("cssIdentifier", s:gui0D, "", "", "", "", "" )
-call s:hi("cssImportant", s:gui0E, "", "", "", "", "" )
-call s:hi("cssInclude", s:gui05, "", "", "", "", "" )
-call s:hi("cssIncludeKeyword", s:gui0E, "", "", "", "", "" )
-call s:hi("cssMediaType", s:gui0A, "", "", "", "", "" )
-call s:hi("cssProp", s:gui05, "", "", "", "", "" )
-call s:hi("cssPseudoClassId", s:gui0A, "", "", "", "", "" )
-call s:hi("cssSelectorOp", s:gui0E, "", "", "", "", "" )
-call s:hi("cssSelectorOp2", s:gui0E, "", "", "", "", "" )
-call s:hi("cssTagName", s:gui08, "", "", "", "", "" )
+call s:hi("cssAttrComma", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssAttributeSelector", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("cssBraces", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssClassName", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("cssClassNameDot", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("cssDefinition", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssFontAttr", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("cssFontDescriptor", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssFunctionName", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("cssIdentifier", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("cssImportant", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssInclude", s:colors.gui05, "", "", "", "", "" )
+call s:hi("cssIncludeKeyword", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssMediaType", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("cssProp", s:colors.gui05, "", "", "", "", "" )
+call s:hi("cssPseudoClassId", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("cssSelectorOp", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssSelectorOp2", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("cssTagName", s:colors.gui08, "", "", "", "", "" )
 
 "+----------------------+
 "+ Java Lang Hightlight +
 "+----------------------+
 " > Java motherfucker! Do you speak it?!?!
-call s:hi("javaAnnotation", s:gui0C, "", "", "", "italic", "")
-call s:hi("javaDocTags", s:gui0A, "", "", "", "italic", "")
-call s:hi("javaCommentTitle", s:gui03, "", "", "", "italic", "")
-call s:hi("javaParen", s:gui03, "", "", "", "italic", "")
-call s:hi("javaParen1", s:gui0B, "", "", "", "", "")
-call s:hi("javaParen2", s:gui0B, "", "", "", "", "")
-call s:hi("javaParen3", s:gui0B, "", "", "", "", "")
-call s:hi("javaParen4", s:gui0B, "", "", "", "", "")
-call s:hi("javaParen5", s:gui0B, "", "", "", "", "")
-call s:hi("javaVarArg", s:gui0C, "", "", "", "", "")
+call s:hi("javaAnnotation", s:colors.gui0C, "", "", "", "italic", "")
+call s:hi("javaDocTags", s:colors.gui0A, "", "", "", "italic", "")
+call s:hi("javaCommentTitle", s:colors.gui03, "", "", "", "italic", "")
+call s:hi("javaParen", s:colors.gui03, "", "", "", "italic", "")
+call s:hi("javaParen1", s:colors.gui0B, "", "", "", "", "")
+call s:hi("javaParen2", s:colors.gui0B, "", "", "", "", "")
+call s:hi("javaParen3", s:colors.gui0B, "", "", "", "", "")
+call s:hi("javaParen4", s:colors.gui0B, "", "", "", "", "")
+call s:hi("javaParen5", s:colors.gui0B, "", "", "", "", "")
+call s:hi("javaVarArg", s:colors.gui0C, "", "", "", "", "")
 
 "+---------------------------+
 "+ Vimscript Lang Hightlight +
 "+---------------------------+
-call s:hi("vimCommentTitle", s:gui0D, "", "", "", "italic", "")
-call s:hi("vimBracket", s:gui0E, "", "", "", "", "")
-call s:hi("vimMapModKey", s:gui0D, "", "", "", "italic", "")
-call s:hi("vimFuncSID", s:gui0D, "", "", "", "italic", "")
-call s:hi("vimSetSep", s:gui0C, "", "", "", "", "")
-call s:hi("vimSep", s:gui08, "", "", "", "", "")
-call s:hi("vimContinue", s:gui0D, "", "", "", "", "")
-call s:hi("vimNotation", s:gui0A, "", "", "", "", "")
-call s:hi("vimOper", s:gui0E, "", "", "", "", "")
+call s:hi("vimCommentTitle", s:colors.gui0D, "", "", "", "italic", "")
+call s:hi("vimBracket", s:colors.gui0E, "", "", "", "", "")
+call s:hi("vimMapModKey", s:colors.gui0D, "", "", "", "italic", "")
+call s:hi("vimFuncSID", s:colors.gui0D, "", "", "", "italic", "")
+call s:hi("vimSetSep", s:colors.gui0C, "", "", "", "", "")
+call s:hi("vimSep", s:colors.gui08, "", "", "", "", "")
+call s:hi("vimContinue", s:colors.gui0D, "", "", "", "", "")
+call s:hi("vimNotation", s:colors.gui0A, "", "", "", "", "")
+call s:hi("vimOper", s:colors.gui0E, "", "", "", "", "")
 
 "+----------------------+
 "+ JSON Lang Hightlight +
 "+----------------------+
-call s:hi("jsonCommentError", s:gui0E, "", "", "", "", "")
-call s:hi("jsonKeyword", s:gui08, "", "", "", "", "")
-call s:hi("jsonBoolean", s:gui09, "", "", "", "", "")
-call s:hi("jsonNumber", s:gui09, "", "", "", "", "")
-call s:hi("jsonQuote", s:gui0C, "", "", "", "", "")
-call s:hi("jsonMissingCommaError", s:gui08, "", "", "", "reverse", "")
-call s:hi("jsonNoQuotesError", s:gui0F, "", "", "", "reverse", "")
-call s:hi("jsonNumError", s:gui0F, "", "", "", "reverse", "")
-call s:hi("jsonString", s:gui0B, "", "", "", "", "")
-call s:hi("jsonStringSQError", s:gui08, "", "", "", "reverse", "")
-call s:hi("jsonSemicolonError", s:gui08, "", "", "", "reverse", "")
+call s:hi("jsonCommentError", s:colors.gui0E, "", "", "", "", "")
+call s:hi("jsonKeyword", s:colors.gui08, "", "", "", "", "")
+call s:hi("jsonBoolean", s:colors.gui09, "", "", "", "", "")
+call s:hi("jsonNumber", s:colors.gui09, "", "", "", "", "")
+call s:hi("jsonQuote", s:colors.gui0C, "", "", "", "", "")
+call s:hi("jsonMissingCommaError", s:colors.gui08, "", "", "", "reverse", "")
+call s:hi("jsonNoQuotesError", s:colors.gui0F, "", "", "", "reverse", "")
+call s:hi("jsonNumError", s:colors.gui0F, "", "", "", "reverse", "")
+call s:hi("jsonString", s:colors.gui0B, "", "", "", "", "")
+call s:hi("jsonStringSQError", s:colors.gui08, "", "", "", "reverse", "")
+call s:hi("jsonSemicolonError", s:colors.gui08, "", "", "", "reverse", "")
 
 "+-------------------------+
 "+ Markdown Lang Highlight +
 "+-------------------------+
-call s:hi("markdownBlockquote", s:gui0E, "", "", "", "", "" )
-call s:hi("markdownBold", s:gui0A, "", "", "", s:bold, "")
-call s:hi("markdownCode", s:gui0B, "", "", "", "", "")
-call s:hi("markdownCodeBlock", s:gui0B, "", "", "", "", "")
-call s:hi("markdownCodeDelimiter", s:gui0B, "", "", "", "", "")
-call s:hi("markdownH1", s:gui08, "", "", "", "", "")
-call s:hi("markdownH2", s:gui08, "", "", "", "", "" )
-call s:hi("markdownH3", s:gui08, "", "", "", "", "" )
-call s:hi("markdownH4", s:gui08, "", "", "", "", "" )
-call s:hi("markdownH5", s:gui08, "", "", "", "", "" )
-call s:hi("markdownH6", s:gui08, "", "", "", "", "" )
-call s:hi("markdownHeadingDelimiter", s:gui08, "", "", "", "", "")
-call s:hi("markdownHeadingRule", s:gui0C, "", "", "", "", "")
-call s:hi("markdownId", s:gui0E, "", "", "", "", "")
-call s:hi("markdownIdDeclaration", s:gui0D, "", "", "", "", "")
-call s:hi("markdownIdDelimiter", s:gui0E, "", "", "", "", "")
-call s:hi("markdownItalic", s:gui0E, "", "", "", "italic", "")
-call s:hi("markdownLinkDelimiter", s:gui0E, "", "", "", "", "")
-call s:hi("markdownLinkText", s:gui0D, "", "", "", "", "")
-call s:hi("markdownListMarker", s:gui08, "", "", "", "", "")
-call s:hi("markdownOrderedListMarker", s:gui08, "", "", "", "", "")
-call s:hi("markdownRule", s:gui0D, "", "", "", "", "")
-call s:hi("markdownUrl", s:gui0C, "", "", "", "undercurl", "")
+call s:hi("markdownBlockquote", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("markdownBold", s:colors.gui0A, "", "", "", s:colors.bold, "")
+call s:hi("markdownCode", s:colors.gui0B, "", "", "", "", "")
+call s:hi("markdownCodeBlock", s:colors.gui0B, "", "", "", "", "")
+call s:hi("markdownCodeDelimiter", s:colors.gui0B, "", "", "", "", "")
+call s:hi("markdownH1", s:colors.gui08, "", "", "", "", "")
+call s:hi("markdownH2", s:colors.gui08, "", "", "", "", "" )
+call s:hi("markdownH3", s:colors.gui08, "", "", "", "", "" )
+call s:hi("markdownH4", s:colors.gui08, "", "", "", "", "" )
+call s:hi("markdownH5", s:colors.gui08, "", "", "", "", "" )
+call s:hi("markdownH6", s:colors.gui08, "", "", "", "", "" )
+call s:hi("markdownHeadingDelimiter", s:colors.gui08, "", "", "", "", "")
+call s:hi("markdownHeadingRule", s:colors.gui0C, "", "", "", "", "")
+call s:hi("markdownId", s:colors.gui0E, "", "", "", "", "")
+call s:hi("markdownIdDeclaration", s:colors.gui0D, "", "", "", "", "")
+call s:hi("markdownIdDelimiter", s:colors.gui0E, "", "", "", "", "")
+call s:hi("markdownItalic", s:colors.gui0E, "", "", "", "italic", "")
+call s:hi("markdownLinkDelimiter", s:colors.gui0E, "", "", "", "", "")
+call s:hi("markdownLinkText", s:colors.gui0D, "", "", "", "", "")
+call s:hi("markdownListMarker", s:colors.gui08, "", "", "", "", "")
+call s:hi("markdownOrderedListMarker", s:colors.gui08, "", "", "", "", "")
+call s:hi("markdownRule", s:colors.gui0D, "", "", "", "", "")
+call s:hi("markdownUrl", s:colors.gui0C, "", "", "", "undercurl", "")
 
 "+------------------------+
 "+ Haskel Lang Hightlight +
 "+------------------------+
-call s:hi("haskellType", s:gui0A, "", "", "", "", "")
-call s:hi("haskellOperators", s:gui0C, "", "", "", "", "")
-call s:hi("haskellNumber", s:gui09, "", "", "", "", "")
-call s:hi("haskellPragma", s:gui0E, "", "", "", "", "")
+call s:hi("haskellType", s:colors.gui0A, "", "", "", "", "")
+call s:hi("haskellOperators", s:colors.gui0C, "", "", "", "", "")
+call s:hi("haskellNumber", s:colors.gui09, "", "", "", "", "")
+call s:hi("haskellPragma", s:colors.gui0E, "", "", "", "", "")
 
 "+----------------------------+
 "+ JavaScript Lang Hightlight +
 "+----------------------------+
-call s:hi("javaScriptBraces", s:gui0C, "", "", "", "", "")
-call s:hi("javaScriptFunction", s:gui0A, "", "", "", "", "")
-call s:hi("javaScriptIdentifier", s:gui0A, "", "", "", "", "")
-call s:hi("javaScriptNull", s:gui08, "", "", "", "", "")
-call s:hi("javaScriptNumber", s:gui09, "", "", "", "", "")
-call s:hi("javaScriptRequire", s:gui0C, "", "", "", "", "")
-call s:hi("javaScriptReserved", s:gui0E, "", "", "", "", "" )
-" https://github.com/pangloss/vim-javascript
-call s:hi("jsArrowFunction", s:gui0E, "", "", "", "", "" )
-call s:hi("jsClassKeyword", s:gui0E, "", "", "", "", "" )
-call s:hi("jsClassMethodType", s:gui0E, "", "", "", "", "" )
-call s:hi("jsDocParam", s:gui0D, "", "", "", "", "" )
-call s:hi("jsDocTags", s:gui0E, "", "", "", "", "" )
-call s:hi("jsExport", s:gui0E, "", "", "", "", "" )
-call s:hi("jsExportDefault", s:gui0E, "", "", "", "", "" )
-call s:hi("jsExtendsKeyword", s:gui0E, "", "", "", "", "" )
-call s:hi("jsFrom", s:gui0E, "", "", "", "", "" )
-call s:hi("jsFuncCall", s:gui0D, "", "", "", "", "" )
-call s:hi("jsFunction", s:gui0E, "", "", "", "", "" )
-call s:hi("jsGenerator", s:gui0A, "", "", "", "", "" )
-call s:hi("jsGlobalObjects", s:gui0A, "", "", "", "", "" )
-call s:hi("jsImport", s:gui0E, "", "", "", "", "" )
-call s:hi("jsModuleAs", s:gui0E, "", "", "", "", "" )
-call s:hi("jsModuleWords", s:gui0E, "", "", "", "", "" )
-call s:hi("jsModules", s:gui0E, "", "", "", "", "" )
-call s:hi("jsNull", s:gui0A, "", "", "", "", "" )
-call s:hi("jsOperator", s:gui0E, "", "", "", "", "" )
-call s:hi("jsStorageClass", s:gui0E, "", "", "", "", "" )
-call s:hi("jsSuper", s:gui08, "", "", "", "", "" )
-call s:hi("jsTemplateBraces", s:gui08, "", "", "", "", "" )
-call s:hi("jsTemplateVar", s:gui0B, "", "", "", "", "" )
-call s:hi("jsThis", s:gui08, "", "", "", "", "" )
-call s:hi("jsUndefined", s:gui0A, "", "", "", "", "" )
+call s:hi("javaScriptBraces", s:colors.gui0C, "", "", "", "", "")
+call s:hi("javaScriptFunction", s:colors.gui0A, "", "", "", "", "")
+call s:hi("javaScriptIdentifier", s:colors.gui0A, "", "", "", "", "")
+call s:hi("javaScriptNull", s:colors.gui08, "", "", "", "", "")
+call s:hi("javaScriptNumber", s:colors.gui09, "", "", "", "", "")
+call s:hi("javaScriptRequire", s:colors.gui0C, "", "", "", "", "")
+call s:hi("javaScriptReserved", s:colors.gui0E, "", "", "", "", "" )
+" https:colors.//github.com/pangloss/vim-javascript
+call s:hi("jsArrowFunction", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsClassKeyword", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsClassMethodType", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsDocParam", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("jsDocTags", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsExport", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsExportDefault", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsExtendsKeyword", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsFrom", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsFuncCall", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("jsFunction", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsGenerator", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("jsGlobalObjects", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("jsImport", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsModuleAs", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsModuleWords", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsModules", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsNull", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("jsOperator", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsStorageClass", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("jsSuper", s:colors.gui08, "", "", "", "", "" )
+call s:hi("jsTemplateBraces", s:colors.gui08, "", "", "", "", "" )
+call s:hi("jsTemplateVar", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("jsThis", s:colors.gui08, "", "", "", "", "" )
+call s:hi("jsUndefined", s:colors.gui0A, "", "", "", "", "" )
 
 "+----------------------+
 "+ Lisp Lang Hightlight +
@@ -657,17 +515,17 @@ call s:hi("jsUndefined", s:gui0A, "", "", "", "", "" )
 "+----------------------------+
 "+ Typescript Lang Hightlight +
 "+----------------------------+
-call s:hi("typescriptReserved", s:gui0A, "", "", "", "", "")
-call s:hi("typeScriptLabel", s:gui0C, "", "", "", "", "" )
-call s:hi("typeScriptFuncKeyword", s:gui08, "", "", "", "", "" )
-call s:hi("typeScriptIdentifier", s:gui0C, "", "", "", "", "" )
-call s:hi("typeScriptDOMObjects", s:gui0B, "", "", "", "", "")
-call s:hi("typeScriptAjaxMethods", s:gui0A, "", "", "", "", "")
-call s:hi("typeScriptGlobalObject", s:gui0A, "", "", "", "", "")
-call s:hi("typeScriptInterpolationDelimiter", s:gui0E, "", "", "", "", "")
-call s:hi("typeScriptNull", s:gui0E, "", "", "", "", "")
-call s:hi("typeScriptNull", s:gui0E, "", "", "", "", "")
-call s:hi("typeScriptParens", s:gui08, "", "", "", "", "")
+call s:hi("typescriptReserved", s:colors.gui0A, "", "", "", "", "")
+call s:hi("typeScriptLabel", s:colors.gui0C, "", "", "", "", "" )
+call s:hi("typeScriptFuncKeyword", s:colors.gui08, "", "", "", "", "" )
+call s:hi("typeScriptIdentifier", s:colors.gui0C, "", "", "", "", "" )
+call s:hi("typeScriptDOMObjects", s:colors.gui0B, "", "", "", "", "")
+call s:hi("typeScriptAjaxMethods", s:colors.gui0A, "", "", "", "", "")
+call s:hi("typeScriptGlobalObject", s:colors.gui0A, "", "", "", "", "")
+call s:hi("typeScriptInterpolationDelimiter", s:colors.gui0E, "", "", "", "", "")
+call s:hi("typeScriptNull", s:colors.gui0E, "", "", "", "", "")
+call s:hi("typeScriptNull", s:colors.gui0E, "", "", "", "", "")
+call s:hi("typeScriptParens", s:colors.gui08, "", "", "", "", "")
 hi! link typeScriptOpSymbols Boolean
 hi! link typeScriptHtmlElemProperties Special
 hi! link typeScriptLogicSymbols Boolean
@@ -678,85 +536,85 @@ hi! link typeScriptDocTags vimCommentTitle
 "+---------------------+
 "+ HTML Lang Highlight +
 "+---------------------+
-call s:hi("htmlArg", s:gui0A, "", "", "", "", "")
-call s:hi("htmlBold", s:gui0A, "", "", "", s:bold, "")
-call s:hi("htmlEndTag", s:gui0E, "", "", "", "", "")
-call s:hi("htmlH1", s:gui08, "", "", "", "italic", "")
-call s:hi("htmlH2", s:gui08, "", "", "", "italic", "")
-call s:hi("htmlH3", s:gui08, "", "", "", "italic", "")
-call s:hi("htmlH4", s:gui08, "", "", "", "italic", "")
-call s:hi("htmlH5", s:gui08, "", "", "", "italic", "")
-call s:hi("htmlH6", s:gui08, "", "", "", "italic", "")
-call s:hi("htmlItalic", s:gui0E, "", "", "", "italic", "")
-call s:hi("htmlLink", s:gui0C, "", "", "", "undercurl", "")
-call s:hi("htmlSpecialChar", s:gui0A, "", "", "", "", "")
-call s:hi("htmlSpecialTagName", s:gui08, "", "", "", "", "")
-call s:hi("htmlTag", s:gui0D, "", "", "", "", "")
-call s:hi("htmlTagN", s:gui08, "", "", "", "", "")
-call s:hi("htmlTagName", s:gui08, "", "", "", "", "")
-call s:hi("htmlTitle", s:gui0D, "", "", "", "", "")
+call s:hi("htmlArg", s:colors.gui0A, "", "", "", "", "")
+call s:hi("htmlBold", s:colors.gui0A, "", "", "", s:colors.bold, "")
+call s:hi("htmlEndTag", s:colors.gui0E, "", "", "", "", "")
+call s:hi("htmlH1", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("htmlH2", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("htmlH3", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("htmlH4", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("htmlH5", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("htmlH6", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("htmlItalic", s:colors.gui0E, "", "", "", "italic", "")
+call s:hi("htmlLink", s:colors.gui0C, "", "", "", "undercurl", "")
+call s:hi("htmlSpecialChar", s:colors.gui0A, "", "", "", "", "")
+call s:hi("htmlSpecialTagName", s:colors.gui08, "", "", "", "", "")
+call s:hi("htmlTag", s:colors.gui0D, "", "", "", "", "")
+call s:hi("htmlTagN", s:colors.gui08, "", "", "", "", "")
+call s:hi("htmlTagName", s:colors.gui08, "", "", "", "", "")
+call s:hi("htmlTitle", s:colors.gui0D, "", "", "", "", "")
 
 "+----------------------+
 "+ PHP Lang Hightlight
 "+----------------------+
-call s:hi("phpVarSelector", s:gui08, "", "", "", "", "" )
-call s:hi("phpOperator", s:gui08, "", "", "", "", "")
-call s:hi("phpParent", s:gui0C, "", "", "", "", "")
-call s:hi("phpMemberSelector", s:gui0D, "", "", "", "", "")
-call s:hi("phpType", s:gui0E, "", "", "", "", "")
-call s:hi("phpKeyword", s:gui0E, "", "", "", "", "" )
-call s:hi("phpClass", s:gui0A, "", "", "", "", "" )
-call s:hi("phpUseClass", s:gui0D, "", "", "", "", "" )
-call s:hi("phpUseAlias", s:gui0C, "", "", "", "", "" )
-call s:hi("phpInclude", s:gui0E, "", "", "", "", "" )
-call s:hi("phpClassExtends", s:gui0B, "", "", "", "", "" )
-call s:hi("phpDocTags", s:gui05, "", "", "", "", "" )
-call s:hi("phpFunction", s:gui0D, "", "", "", "", "" )
-call s:hi("phpFunctions", s:gui0C, "", "", "", "", "" )
-call s:hi("phpMethodsVar", s:gui0A, "", "", "", "", "" )
-call s:hi("phpMagicConstants", s:gui0A, "", "", "", "", "" )
-call s:hi("phpSuperglobals", s:gui08, "", "", "", "", "" )
-call s:hi("phpConstants", s:gui0A, "", "", "", "", "" )
+call s:hi("phpVarSelector", s:colors.gui08, "", "", "", "", "" )
+call s:hi("phpOperator", s:colors.gui08, "", "", "", "", "")
+call s:hi("phpParent", s:colors.gui0C, "", "", "", "", "")
+call s:hi("phpMemberSelector", s:colors.gui0D, "", "", "", "", "")
+call s:hi("phpType", s:colors.gui0E, "", "", "", "", "")
+call s:hi("phpKeyword", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("phpClass", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("phpUseClass", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("phpUseAlias", s:colors.gui0C, "", "", "", "", "" )
+call s:hi("phpInclude", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("phpClassExtends", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("phpDocTags", s:colors.gui05, "", "", "", "", "" )
+call s:hi("phpFunction", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("phpFunctions", s:colors.gui0C, "", "", "", "", "" )
+call s:hi("phpMethodsVar", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("phpMagicConstants", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("phpSuperglobals", s:colors.gui08, "", "", "", "", "" )
+call s:hi("phpConstants", s:colors.gui0A, "", "", "", "", "" )
 
 "+--------------------+
 " Perl Lang Highlight +
 "+--------------------+
-call s:hi("perlFiledescRead", s:gui0B, "", "", "", "", "" )
-call s:hi("perlFunction", s:gui0E, "", "", "", "", "" )
-call s:hi("perlMatchStartEnd", s:gui0D, "", "", "", "", "" )
-call s:hi("perlMethod", s:gui0E, "", "", "", "", "" )
-call s:hi("perlPOD", s:gui01, "", "", "", "", "" )
-call s:hi("perlSharpBang", s:gui05, "", "", "", "", "" )
-call s:hi("perlSpecialString", s:gui0B, "", "", "", "", "" )
-call s:hi("perlStatementFiledesc", s:gui08, "", "", "", "", "" )
-call s:hi("perlStatementFlow", s:gui08, "", "", "", "", "" )
-call s:hi("perlStatementInclude", s:gui0E, "", "", "", "", "" )
-call s:hi("perlStatementScalar", s:gui0E, "", "", "", "", "" )
-call s:hi("perlStatementStorage", s:gui0E, "", "", "", "", "" )
-call s:hi("perlSubName", s:gui0A, "", "", "", "", "" )
-call s:hi("perlVarPlain", s:gui0D, "", "", "", "", "" )
+call s:hi("perlFiledescRead", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("perlFunction", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("perlMatchStartEnd", s:colors.gui0D, "", "", "", "", "" )
+call s:hi("perlMethod", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("perlPOD", s:colors.gui01, "", "", "", "", "" )
+call s:hi("perlSharpBang", s:colors.gui05, "", "", "", "", "" )
+call s:hi("perlSpecialString", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("perlStatementFiledesc", s:colors.gui08, "", "", "", "", "" )
+call s:hi("perlStatementFlow", s:colors.gui08, "", "", "", "", "" )
+call s:hi("perlStatementInclude", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("perlStatementScalar", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("perlStatementStorage", s:colors.gui0E, "", "", "", "", "" )
+call s:hi("perlSubName", s:colors.gui0A, "", "", "", "", "" )
+call s:hi("perlVarPlain", s:colors.gui0D, "", "", "", "", "" )
 
 "+---------------------+
 "+ Ruby Lang Highlight +
 "+---------------------+
-call s:hi("rubyBlockParameter", s:gui08, "", "", "", "", "")
-call s:hi("rubyBlockParameterList", s:gui08, "", "", "", "", "")
-call s:hi("rubyClass", s:gui0A, "", "", "", "", "")
-call s:hi("rubyConstant", s:gui0A, "", "", "", "", "")
-call s:hi("rubyControl", s:gui0A, "", "", "", "", "")
-call s:hi("rubyEscape", s:gui08, "", "", "", "", "")
-call s:hi("rubyFunction", s:gui0D, "", "", "", "", "")
-call s:hi("rubyGlobalVariable", s:gui08, "", "", "", "", "")
-call s:hi("rubyInclude", s:gui0D, "", "", "", "", "")
-call s:hi("rubyIncluderubyGlobalVariable", s:gui08, "", "", "", "", "")
-call s:hi("rubyInstanceVariable", s:gui08, "", "", "", "", "")
-call s:hi("rubyInterpolation", s:gui0C, "", "", "", "", "")
-call s:hi("rubyInterpolationDelimiter", s:gui08, "", "", "", "", "")
-call s:hi("rubyInterpolationDelimiter", s:gui08, "", "", "", "", "")
-call s:hi("rubyRegexp", s:gui0C, "", "", "", "", "")
-call s:hi("rubyRegexpDelimiter", s:gui0C, "", "", "", "", "")
-call s:hi("rubyStringDelimiter", s:gui0B, "", "", "", "", "")
-call s:hi("rubySymbol", s:gui0C, "", "", "", "", "")
+call s:hi("rubyBlockParameter", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyBlockParameterList", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyClass", s:colors.gui0A, "", "", "", "", "")
+call s:hi("rubyConstant", s:colors.gui0A, "", "", "", "", "")
+call s:hi("rubyControl", s:colors.gui0A, "", "", "", "", "")
+call s:hi("rubyEscape", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyFunction", s:colors.gui0D, "", "", "", "", "")
+call s:hi("rubyGlobalVariable", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyInclude", s:colors.gui0D, "", "", "", "", "")
+call s:hi("rubyIncluderubyGlobalVariable", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyInstanceVariable", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyInterpolation", s:colors.gui0C, "", "", "", "", "")
+call s:hi("rubyInterpolationDelimiter", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyInterpolationDelimiter", s:colors.gui08, "", "", "", "", "")
+call s:hi("rubyRegexp", s:colors.gui0C, "", "", "", "", "")
+call s:hi("rubyRegexpDelimiter", s:colors.gui0C, "", "", "", "", "")
+call s:hi("rubyStringDelimiter", s:colors.gui0B, "", "", "", "", "")
+call s:hi("rubySymbol", s:colors.gui0C, "", "", "", "", "")
 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -765,59 +623,59 @@ call s:hi("rubySymbol", s:gui0C, "", "", "", "", "")
 
 " fugitive.vim
 " > tpope/vim-fugitive
-call s:hi("gitcommitDiscardedFile", s:gui08, "", "", "", "", "" )
-call s:hi("gitcommitUntrackedFile", s:gui0C, "", "", "", "", "" )
-call s:hi("gitcommitSelectedFile", s:gui0B, "", "", "", "", "" )
-call s:hi("diffAdded", s:gui0B, "", "", "", "", "" )
-call s:hi("diffRemoved", s:gui08, "", "", "", "", "" )
+call s:hi("gitcommitDiscardedFile", s:colors.gui08, "", "", "", "", "" )
+call s:hi("gitcommitUntrackedFile", s:colors.gui0C, "", "", "", "", "" )
+call s:hi("gitcommitSelectedFile", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("diffAdded", s:colors.gui0B, "", "", "", "", "" )
+call s:hi("diffRemoved", s:colors.gui08, "", "", "", "", "" )
 
 " Vim Clap
 " > liuchengxu/vim-clap
-let s:save_cpo = &cpoptions
+let s:colors.save_cpo = &cpoptions
 set cpoptions&vim
-let s:palette = {}
-let s:palette.display = { 'ctermbg': '0', 'guibg': 'gui01' }
+let s:colors.palette = {}
+let s:colors.palette.display = { 'ctermbg': '0', 'guibg': 'gui01' }
 
 " Let ClapInput, ClapSpinner and ClapSearchText use the same background.
-let s:bg0 = { 'ctermbg': '60', 'guibg': s:gui00 }
-let s:palette.input = s:bg0
-let s:palette.indicator = extend({ 'ctermfg': '238', 'guifg': s:gui01 }, s:bg0)
-let s:palette.spinner = extend({ 'ctermfg': '11', 'guifg': s:gui0A, 'cterm': s:bold, 'gui': s:bold }, s:bg0)
-let s:palette.search_text = extend({ 'ctermfg': '4', 'guifg': s:gui0D, 'cterm': s:bold, 'gui': s:bold }, s:bg0)
-let s:palette.preview = { 'ctermbg': '238', 'guibg': s:gui00 }
-let s:palette.selected = { 'ctermfg': '81', 'guifg': s:gui0C, 'cterm': 'bold,underline', 'gui': 'bold,underline' }
-let s:palette.current_selection = { 'ctermbg': '236', 'guibg': s:gui01, 'cterm': s:bold, 'gui': s:bold }
-let s:palette.selected_sign = { 'ctermfg': '196', 'guifg': s:gui0A }
-let s:palette.current_selection_sign = s:palette.selected_sign
+let s:colors.bg0 = { 'ctermbg': '60', 'guibg': s:colors.gui00 }
+let s:colors.palette.input = s:colors.bg0
+let s:colors.palette.indicator = extend({ 'ctermfg': '238', 'guifg': s:colors.gui01 }, s:colors.bg0)
+let s:colors.palette.spinner = extend({ 'ctermfg': '11', 'guifg': s:colors.gui0A, 'cterm': s:colors.bold, 'gui': s:colors.bold }, s:colors.bg0)
+let s:colors.palette.search_text = extend({ 'ctermfg': '4', 'guifg': s:colors.gui0D, 'cterm': s:colors.bold, 'gui': s:colors.bold }, s:colors.bg0)
+let s:colors.palette.preview = { 'ctermbg': '238', 'guibg': s:colors.gui00 }
+let s:colors.palette.selected = { 'ctermfg': '81', 'guifg': s:colors.gui0C, 'cterm': 'bold,underline', 'gui': 'bold,underline' }
+let s:colors.palette.current_selection = { 'ctermbg': '236', 'guibg': s:colors.gui01, 'cterm': s:colors.bold, 'gui': s:colors.bold }
+let s:colors.palette.selected_sign = { 'ctermfg': '196', 'guifg': s:colors.gui0A }
+let s:colors.palette.current_selection_sign = s:colors.palette.selected_sign
 
 hi ClapShadow guibg=#3b3b4d
 
 let g:clap_fuzzy_match_hl_groups = [
-  \ ['75', s:gui0A],
+  \ ['75', s:colors.gui0A],
 \ ]
 
-let g:clap#themes#aquarium#palette = s:palette
-let &cpoptions = s:save_cpo
-unlet s:save_cpo
+let g:clap#themes#aquarium#palette = s:colors.palette
+let &cpoptions = s:colors.save_cpo
+unlet s:colors.save_cpo
 let g:clap_theme = 'aquarium'
 
 " vim-plug
 " > junegunn/vim-plug
-call s:hi("plugDeleted", s:gui08, "", "", "", "italic", "")
+call s:hi("plugDeleted", s:colors.gui08, "", "", "", "italic", "")
 
 " YAML
 " > stephpy/vim-yaml
-call s:hi("yamlKey", s:gui08, "", "", "", "italic", "")
+call s:hi("yamlKey", s:colors.gui08, "", "", "", "italic", "")
 
 " JEDI
 " > davidhalter/jedi-vim
-call s:hi("jediFunction", s:gui0E, s:gui02, "", "", "italic", "")
-call s:hi("jediFat", s:gui0C, s:gui02, "", "", "italic", "")
+call s:hi("jediFunction", s:colors.gui0E, s:colors.gui02, "", "", "italic", "")
+call s:hi("jediFat", s:colors.gui0C, s:colors.gui02, "", "", "italic", "")
 
 " Pandoc
 " > vim-pandoc/vim-pandoc-syntax
-call s:hi("pandocDefinitionBlockTerm", s:gui08, "", "", "", "italic", "")
-call s:hi("pandocTableDelims", s:gui0E, "", "", "", "", "")
+call s:hi("pandocDefinitionBlockTerm", s:colors.gui08, "", "", "", "italic", "")
+call s:hi("pandocTableDelims", s:colors.gui0E, "", "", "", "", "")
 hi! link pandocAtxHeader markdownH1
 hi! link pandocBlockQuote markdownBlockquote
 hi! link pandocCiteAnchor Operator
@@ -841,32 +699,32 @@ hi! link pandocUListItemBullet Operator
 
 " GitGutter
 " > airblade/vim-gitgutter
-call s:hi("GitGutterAdd", s:gui0B, "", "", "", "", "")
-call s:hi("GitGutterChange", s:gui0D, "", "", "", "", "")
-call s:hi("GitGutterDelete", s:gui08, "", "", "", "", "")
-call s:hi("GitGutterChangeDelete", s:gui0E, "", "", "", "", "")
+call s:hi("GitGutterAdd", s:colors.gui0B, "", "", "", "", "")
+call s:hi("GitGutterChange", s:colors.gui0D, "", "", "", "", "")
+call s:hi("GitGutterDelete", s:colors.gui08, "", "", "", "", "")
+call s:hi("GitGutterChangeDelete", s:colors.gui0E, "", "", "", "", "")
 highlight! link GitGutterChangeDelete PurpleSign
 
 " Vim Sneak
 " > justinmk/vim-sneak
-call s:hi("Sneak", s:gui09, s:gui07, "", "", "", "")
-call s:hi("SneakMask", s:gui09, s:gui07, "", "", "", "")
-call s:hi("SneakLabel", s:gui07, s:gui07, "", "", "", "")
-call s:hi("SneakScope", s:gui0B, s:gui07, "", "", "", "")
+call s:hi("Sneak", s:colors.gui09, s:colors.gui07, "", "", "", "")
+call s:hi("SneakMask", s:colors.gui09, s:colors.gui07, "", "", "", "")
+call s:hi("SneakLabel", s:colors.gui07, s:colors.gui07, "", "", "", "")
+call s:hi("SneakScope", s:colors.gui0B, s:colors.gui07, "", "", "", "")
 
 if has('nvim')
 
     " Treesitter
     " > nvim-treesitter/nvim-treesitter
-    call s:hi("Constructor", s:gui02, "", "", "", "", "")
-    call s:hi("Emphasis", s:gui02, "", "", "", "", "")
-    call s:hi("Field", s:gui0B, "", "", "", "", "")
-    call s:hi("FunctionBuiltin", s:gui0D, "", "", "", "", "")
-    call s:hi("FuncMacro", s:gui0E, "", "", "", "", "")
-    call s:hi("Method", s:gui0B, "", "", "", "", "")
-    call s:hi("Parameter", s:gui09, "", "", "", "", "")
-    call s:hi("TypeBuiltin", s:gui0F, "", "", "", "", "")
-    call s:hi("TreeSitterVariable", s:gui0B, "", "", "", "", "")
+    call s:hi("Constructor", s:colors.gui02, "", "", "", "", "")
+    call s:hi("Emphasis", s:colors.gui02, "", "", "", "", "")
+    call s:hi("Field", s:colors.gui0B, "", "", "", "", "")
+    call s:hi("FunctionBuiltin", s:colors.gui0D, "", "", "", "", "")
+    call s:hi("FuncMacro", s:colors.gui0E, "", "", "", "", "")
+    call s:hi("Method", s:colors.gui0B, "", "", "", "", "")
+    call s:hi("Parameter", s:colors.gui09, "", "", "", "", "")
+    call s:hi("TypeBuiltin", s:colors.gui0F, "", "", "", "", "")
+    call s:hi("TreeSitterVariable", s:colors.gui0B, "", "", "", "", "")
     hi! link TSAnnotation PreProc
     hi! link TSAttribute Decorator
     hi! link TSBoolean Boolean
@@ -914,29 +772,29 @@ if has('nvim')
 
     " NvimTree
     " >  kyazdani42/nvim-tree.lua
-    call s:hi("NvimTreeExecFile", s:gui0B, "", "", "", "", "")
-    call s:hi("NvimTreeOpenedFile", s:gui0A, "", "", "", "bold", "")
-    call s:hi("NvimTreeSpecialFile", s:gui09, "", "", "", "italic", "")
-    call s:hi("NvimTreeMarkdownFile", s:gui09, "", "", "", "", "")
-    call s:hi("NvimTreeImageFile", s:gui0E, "", "", "", "", "")
-    call s:hi("NvimTreeRootFolder", s:gui0C, "", "", "", "italic", "")
-    call s:hi("NvimTreeFolderName", s:gui02, "", "", "", "", "")
-    call s:hi("NvimTreeFolderNormal", "", s:gui07, "", "", "", "")
+    call s:hi("NvimTreeExecFile", s:colors.gui0B, "", "", "", "", "")
+    call s:hi("NvimTreeOpenedFile", s:colors.gui0A, "", "", "", s:colors.bold, "")
+    call s:hi("NvimTreeSpecialFile", s:colors.gui09, "", "", "", "italic", "")
+    call s:hi("NvimTreeMarkdownFile", s:colors.gui09, "", "", "", "", "")
+    call s:hi("NvimTreeImageFile", s:colors.gui0E, "", "", "", "", "")
+    call s:hi("NvimTreeRootFolder", s:colors.gui0C, "", "", "", "italic", "")
+    call s:hi("NvimTreeFolderName", s:colors.gui02, "", "", "", "", "")
+    call s:hi("NvimTreeFolderNormal", "", s:colors.gui07, "", "", "", "")
 
     hi! link LspDiagnosticsError Error
     hi! link LspDiagnosticsWarning healthWarning
     hi! link LspDiagnosticsInformation NvimTreeSpecialFile
     hi! link LspDiagnosticsHint Label
 
-    call s:hi("NvimTreeGitDirty", s:gui08, "", "", "", "underline", "")
-    call s:hi("NvimTreeGitStaged", s:gui0B, "", "", "", "", "")
-    call s:hi("NvimTreeGitMerge", s:gui0C, "", "", "", "", "")
+    call s:hi("NvimTreeGitDirty", s:colors.gui08, "", "", "", "underline", "")
+    call s:hi("NvimTreeGitStaged", s:colors.gui0B, "", "", "", "", "")
+    call s:hi("NvimTreeGitMerge", s:colors.gui0C, "", "", "", "", "")
 
     hi! link NvimTreeGitRenamed GitGutterChange
     hi! link NvimTreeGitNew GitGutterAdd
     hi! link NvimTreeGitDeleted GitGutterDelete
 
-    call s:hi("NvimTreeWindowPicker", s:gui03, "", "", "", "", "")
+    call s:hi("NvimTreeWindowPicker", s:colors.gui03, "", "", "", "", "")
 
 end
 

--- a/colors/aquarium.vim
+++ b/colors/aquarium.vim
@@ -13,8 +13,6 @@ if version > 580
 endif
 
 " --| C O N F I G U R A T I O N |--
-" Background, stuff
-set background=dark
 
 " Naming
 let colors_name = "aquarium"
@@ -22,7 +20,7 @@ let s:aquarium_vim_version="0.3.5"
 
 " Options
 let s:configuration = {}
-let s:configuration.style = get(g:, 'aquarium_style', 'dark')
+let s:configuration.style = get(g:, 'aquarium_style', &background)
 
 " Trigger bold
 if !exists("g:aqua_bold")

--- a/colors/aquarium.vim
+++ b/colors/aquarium.vim
@@ -60,7 +60,6 @@ if s:configuration.style ==# 'dark'
     let s:gui0D     = "#CDDBF9"
     let s:gui0E     = "#F6BBE7"
     let s:gui0F     = "#EAC1C1"
-    let s:gui10     = "#3D4059"
 
     " OTHER
     let s:linenr_bg = s:gui07
@@ -73,7 +72,7 @@ elseif s:configuration.style ==# 'light'
     " Old BG -> #E6E6F1 #E1E3F2
     let s:gui00     = "#E6E6F1"
     let s:gui01     = "#D5D4E0"
-    let s:gui02     = "#E1E1EC"
+    let s:gui02     = "#7F8E9D"
     let s:gui03     = "#CCCBD9"
     let s:gui06     = "#9CA6B9"
     let s:gui07     = "#D7D7E2"
@@ -91,7 +90,6 @@ elseif s:configuration.style ==# 'light'
     let s:gui0D     = "#6A8CBC"
     let s:gui0E     = "#8787BF"
     let s:gui0F     = "#E06B6B"
-    let s:gui10     = "#CCCBD9"
 
     " OTHER
     let s:linenr_bg = s:gui01
@@ -243,7 +241,7 @@ call s:hi("CursorLineNr", s:linenr_fg, s:linenr_bg, "NONE", "", "NONE", "") " Ch
 
 " Tabs
 call s:hi("TabLineFill", s:gui0D, s:gui01, "NONE", "NONE", "NONE", "NONE")
-call s:hi("TabLineSel", s:gui10, s:gui0F, "NONE", "NONE", "bold", "NONE")
+call s:hi("TabLineSel", s:gui03, s:gui0F, "NONE", "NONE", "bold", "NONE")
 call s:hi("TabLine", s:gui05, s:gui00, "NONE", "NONE", "NONE", "NONE") 
 
 "+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/lua/lualine/themes/aquarium.lua
+++ b/lua/lualine/themes/aquarium.lua
@@ -1,50 +1,33 @@
-local colors = {
-    green           = '#B1DBA4',
-    pink            = '#F6BBE7',
-    blue            = '#B8DCEB',
-    lightblue       = '#CDDBF9',
-    red             = '#EBB9B9',
-    lightred        = '#EAC1C1',
-    yellow          = '#E6DFB8',
-    lightyellow     = '#C8CCA7',
-    black           = '#1A1A24',
-    black1          = '#20202A',
-    black2          = '#2C2E3E',
-    black3          = '#313449',
-    black4          = '#3d4059',
-    grey            = '#63718b',
-    grey1           = '#a7b7d6',
-    grey2           = '#cddbf9'
-}
+local colors = vim.fn['aquarium#colors#definitions']()
 return {
     normal = {
-        a = {bg = colors.red, fg = colors.black4, gui = 'bold'},
-        b = {bg = colors.black2, fg = colors.grey2},
-        c = {bg = colors.black4, fg = colors.grey2}
+        a = {bg = colors.gui0F, fg = colors.gui03, gui = colors.bold},
+        b = {bg = colors.gui01, fg = colors.gui04},
+        c = {bg = colors.gui03, fg = colors.gui04}
     },
     insert = {
-        a = {bg = colors.green, fg = colors.black4, gui = 'bold'},
-        b = {bg = colors.blue, fg = colors.black4},
-        c = {bg = colors.black4, fg = colors.grey2}
+        a = {bg = colors.gui0B, fg = colors.gui03, gui = colors.bold},
+        b = {bg = colors.gui0C, fg = colors.gui03},
+        c = {bg = colors.gui03, fg = colors.gui04}
     },
     visual = {
-        a = {bg = colors.black3, fg = colors.grey2, gui = 'bold'},
-        b = {bg = colors.grey, fg = colors.black4},
-        c = {bg = colors.black4, fg = colors.grey2}
+        a = {bg = colors.gui06, fg = colors.gui04, gui = colors.bold},
+        b = {bg = colors.gui05, fg = colors.gui03},
+        c = {bg = colors.gui03, fg = colors.gui04}
     },
     replace = {
-        a = {bg = colors.pink, fg = colors.black4, gui = 'bold'},
-        b = {bg = colors.black3, fg = colors.grey2},
-        c = {bg = colors.black4, fg = colors.grey2}
+        a = {bg = colors.gui0E, fg = colors.gui03, gui = colors.bold},
+        b = {bg = colors.gui06, fg = colors.gui04},
+        c = {bg = colors.gui03, fg = colors.gui04}
     },
     command = {
-        a = {bg = colors.pink, fg = colors.black4, gui = 'bold'},
-        b = {bg = colors.lightblue, fg = colors.black4},
-        c = {bg = colors.black4, fg = colors.grey2}
+        a = {bg = colors.gui0E, fg = colors.gui03, gui = colors.bold},
+        b = {bg = colors.gui0D, fg = colors.gui03},
+        c = {bg = colors.gui03, fg = colors.gui04}
     },
     inactive = {
-        a = {bg = colors.black4, fg = colors.grey2, gui = 'bold'},
-        b = {bg = colors.black4, fg = colors.grey2},
-        c = {bg = colors.black4, fg = colors.grey2}
+        a = {bg = colors.gui03, fg = colors.gui04, gui = colors.bold},
+        b = {bg = colors.gui03, fg = colors.gui04},
+        c = {bg = colors.gui03, fg = colors.gui04}
     }
 }


### PR DESCRIPTION
Granted, this is a mess of four incremental changes, please tell me if you'd prefer to see them as four separate PRs.

These changes implement, each in a separate commit:
- TabLine, TabLineSel, and TabLineFill highlight groups - something important for anyone who's using tab groups
- Use of background setting, as opposed to forcing it - now colours change as you change your background
- Fix for nvim-tree.lua folders color matching background color in light palette - a color that matches the position of the dark palette was selected instead
- lualine dynamic color switching, using central definition of theme colors - any future updates to this theme will propagate to lualine (lightline and airline would take too much time for me, my apologies)

Here's how it looks now with lualine and a heavily modified luatab:

Dark background
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/314453/146909364-33baea0f-c049-441b-ba3b-5b70ce874699.png">

Light background, as a reaction to `set background=light`
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/314453/146909492-327ea3c1-c79c-4afc-869e-d567b689904c.png">

Mish style, with theme reload
<img width="1847" alt="image" src="https://user-images.githubusercontent.com/314453/146909642-36c94f81-2ab7-486c-8419-019ea206e468.png">